### PR TITLE
fix issue #1 generateRootCA promise not being called

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -122,10 +122,12 @@ class Generator {
             path: this.rootKeyPath,
             content: privateKey
           })
-            .then({
-              cert: certificate,
-              key: privateKey
-            }, next)
+            .then(() => {
+              next(null, {
+                cert: certificate,
+                key: privateKey
+              });
+            })
             .catch(next);
         }
       ], (error, result) => {


### PR DESCRIPTION
Explicitly call `next` function with `null` error and keys as second parameter so that the `async` waterfall chain resolves OK.